### PR TITLE
Fix: Adds missing coma to POST body

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -1759,7 +1759,7 @@
                 "value": "application/json"
             }
         ],
-        "postBody": "{\r\n  \"displayName\": \"reviewSet Query created from Graph Explorer\"\r\n  \"query\": \"(subject:'Quartely Financials')\"\r\n}",
+        "postBody": "{\r\n  \"displayName\": \"reviewSet Query created from Graph Explorer\",\r\n  \"query\": \"(subject:'Quartely Financials')\"\r\n}",
         "tip": "Replace {caseId} with the ID from an eDiscovery Case (https://graph.microsoft.com/beta/compliance/ediscovery/cases) and {reviewSetId} with the ID from a review set that exists in that case (https://graph.microsoft.com/beta/compliance/ediscovery/cases/{caseid}/reviewSets)",
         "skipTest": false
     },


### PR DESCRIPTION
The Compliance (beta) POST for create review set query currently has a bug in its `postBody` section; hence failing to render appropriately on GE. There is a missing `,`. This PR fixes this.