### PR TITLE
Updates permissions descriptions from Service Principal

### DIFF
--- a/permissions/permissions-descriptions.json
+++ b/permissions/permissions-descriptions.json
@@ -1,6 +1,46 @@
 {
   "delegatedScopesList": [
     {
+      "adminConsentDescription": "Allows the app to read and write eDiscovery objects such as cases, custodians, review sets and other related objects on behalf of the signed-in user.",
+      "adminConsentDisplayName": "Read and write all eDiscovery objects",
+      "id": "acb8f680-0834-4146-b69e-4ab1b39745ad",
+      "isEnabled": true,
+      "isAdmin": true,
+      "consentDescription": "Allows the app to read and write eDiscovery objects such as cases, custodians, review sets and other related objects on your behalf.",
+      "consentDisplayName": "Read and write all eDiscovery objects",
+      "value": "eDiscovery.ReadWrite.All"
+    },
+    {
+      "adminConsentDescription": "Allows the app to read eDiscovery objects such as cases, custodians, review sets and other related objects on behalf of the signed-in user.",
+      "adminConsentDisplayName": "Read all eDiscovery objects",
+      "id": "99201db3-7652-4d5a-809a-bdb94f85fe3c",
+      "isEnabled": true,
+      "isAdmin": true,
+      "consentDescription": "Allows the app to read eDiscovery objects such as cases, custodians, review sets and other related objects on your behalf.",
+      "consentDisplayName": "Read all eDiscovery objects",
+      "value": "eDiscovery.Read.All"
+    },
+    {
+      "adminConsentDescription": "Allows the app to read and write custom security attribute assignments for all principals in the tenant on behalf of a signed in user.",
+      "adminConsentDisplayName": "Read and write custom security attribute assignments",
+      "id": "ca46335e-8453-47cd-a001-8459884efeae",
+      "isEnabled": true,
+      "isAdmin": true,
+      "consentDescription": "Allows the app to read and write custom security attribute assignments for all principals in the tenant on your behalf.",
+      "consentDisplayName": "Read and write custom security attribute assignments",
+      "value": "CustomSecAttributeAssignment.ReadWrite.All"
+    },
+    {
+      "adminConsentDescription": "Allows the app to read and write custom security attribute definitions for the tenant on behalf of a signed in user.",
+      "adminConsentDisplayName": "Read and write custom security attribute definitions",
+      "id": "8b0160d4-5743-482b-bb27-efc0a485ca4a",
+      "isEnabled": true,
+      "isAdmin": true,
+      "consentDescription": "Allows the app to read and write custom security attribute definitions for the tenant on your behalf.",
+      "consentDisplayName": "Read and write custom security attribute definitions",
+      "value": "CustomSecAttributeDefinition.ReadWrite.All"
+    },
+    {
       "adminConsentDescription": "Allows the application to create print jobs on behalf of the signed-in user and upload document content to print jobs that the signed-in user created.",
       "adminConsentDisplayName": "Create print jobs",
       "id": "21f0d9c0-9f13-48b3-94e0-b6b231c7d320",
@@ -2812,6 +2852,72 @@
     }
   ],
   "applicationScopesList": [
+    {
+      "allowedMemberTypes": [
+        "Application"
+      ],
+      "consentDescription": "Allows the app to read terms of use acceptance statuses, without a signed in user.",
+      "consentDisplayName": "Read all terms of use acceptance statuses",
+      "id": "d8e4ec18-f6c0-4620-8122-c8b1f2bf400e",
+      "isEnabled": true,
+      "isAdmin": false,
+      "value": "AgreementAcceptance.Read.All"
+    },
+    {
+      "allowedMemberTypes": [
+        "Application"
+      ],
+      "consentDescription": "Allows the app to read and write terms of use agreements, without a signed in user.",
+      "consentDisplayName": "Read and write all terms of use agreements",
+      "id": "c9090d00-6101-42f0-a729-c41074260d47",
+      "isEnabled": true,
+      "isAdmin": false,
+      "value": "Agreement.ReadWrite.All"
+    },
+    {
+      "allowedMemberTypes": [
+        "Application"
+      ],
+      "consentDescription": "Allows the app to read terms of use agreements, without a signed in user.",
+      "consentDisplayName": "Read all terms of use agreements",
+      "id": "2f3e6f8c-093b-4c57-a58b-ba5ce494a169",
+      "isEnabled": true,
+      "isAdmin": false,
+      "value": "Agreement.Read.All"
+    },
+    {
+      "allowedMemberTypes": [
+        "Application"
+      ],
+      "consentDescription": "Allows the app to read app consent requests and approvals, and deny or approve those requests without a signed-in user.",
+      "consentDisplayName": "Read and write all consent requests",
+      "id": "9f1b81a7-0223-4428-bfa4-0bcb5535f27d",
+      "isEnabled": true,
+      "isAdmin": false,
+      "value": "ConsentRequest.ReadWrite.All"
+    },
+    {
+      "allowedMemberTypes": [
+        "Application"
+      ],
+      "consentDescription": "Allows the app to read and write your organization's consent requests policy without a signed-in user.",
+      "consentDisplayName": "Read and write your organization's consent request policy",
+      "id": "999f8c63-0a38-4f1b-91fd-ed1947bdd1a9",
+      "isEnabled": true,
+      "isAdmin": false,
+      "value": "Policy.ReadWrite.ConsentRequest"
+    },
+    {
+      "allowedMemberTypes": [
+        "Application"
+      ],
+      "consentDescription": "Allows the app to read consent requests and approvals without a signed-in user.",
+      "consentDisplayName": "Read all consent requests",
+      "id": "1260ad83-98fb-4785-abbb-d6cc1806fd41",
+      "isEnabled": true,
+      "isAdmin": false,
+      "value": "ConsentRequest.Read.All"
+    },
     {
       "allowedMemberTypes": [
         "Application"


### PR DESCRIPTION
Update the descriptions manually because the list of scopes have been reversed in the Service Principal and this causes a huge diff. when these are PR'd automatically by the `permissions-scraper-bot`