### PR TITLE
Fixes incorrect JSON block for sample

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -2284,7 +2284,9 @@
         "humanName": "get a specified azure ad device",
         "requestUrl": "/v1/devices/{id}",
         "docLink": "https://docs.microsoft.com/en-us/graph/api/device-get?view=graph-rest-1.0&tabs=http",
-        "tip": "We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/deviceAPIFeedback",
+        "tip": "We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/deviceAPIFeedback"
+    },
+    {
         "id": "64ca0722-6ee9-4e31-8b59-90dc6a05bb1e",
         "category": "Identity and Access",
         "method": "GET",

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -2284,7 +2284,8 @@
         "humanName": "get a specified azure ad device",
         "requestUrl": "/v1/devices/{id}",
         "docLink": "https://docs.microsoft.com/en-us/graph/api/device-get?view=graph-rest-1.0&tabs=http",
-        "tip": "We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/deviceAPIFeedback"
+        "tip": "We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/deviceAPIFeedback",
+        "skipTest": false
     },
     {
         "id": "64ca0722-6ee9-4e31-8b59-90dc6a05bb1e",


### PR DESCRIPTION
Two sample queries were merged within one JSON block as shown in the image below.
![image](https://user-images.githubusercontent.com/40403681/109781996-77bf8980-7c19-11eb-911e-44445f609f43.png)

This PR breaks the two sample queries appropriately by appending the necessary braces.
