### PR TITLE
Fixes broken urls

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -2289,7 +2289,7 @@
         "category": "Identity and Access",
         "method": "GET",
         "humanName": "list azure ad devices",
-        "requestUrl": "/v1/devices",
+        "requestUrl": "/v1.0/devices",
         "docLink": "https://docs.microsoft.com/en-us/graph/api/device-list?view=graph-rest-1.0&tabs=http",
         "tip": "We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/deviceAPIFeedback",
         "skipTest": false
@@ -2299,7 +2299,7 @@
         "category": "Identity and Access",
         "method": "GET",
         "humanName": "get a specified azure ad device",
-        "requestUrl": "/v1/devices/{id}",
+        "requestUrl": "/v1.0/devices/{id}",
         "docLink": "https://docs.microsoft.com/en-us/graph/api/device-get?view=graph-rest-1.0&tabs=http",
         "tip": "We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/deviceAPIFeedback",
         "skipTest": false


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-explorer-v4/issues/928

This PR fixes two broken urls that causes an unexpected experience at GE. The two samples were missing the full v1.0 moniker in their urls.