### PR TITLE
Fix: Correct invalid docLink urls

### DIFF
--- a/sample-queries/sample-queries_ja-JP.json
+++ b/sample-queries/sample-queries_ja-JP.json
@@ -151,7 +151,7 @@
         "method": "GET",
         "humanName": "自分",
         "requestUrl": "/v1.0/me",
-        "docLink": "://developer.microsoft.com/ja-JP/graph/docs/api-reference/v1.0/resources/user",
+        "docLink": "https://developer.microsoft.com/ja-JP/graph/docs/api-reference/v1.0/resources/user",
         "tip": "ご意見をお聞かせください。ここにこの API に関するフィードバックを入力してください。https://aka.ms/UsersAPIFeedback",
         "skipTest": false
     },
@@ -187,7 +187,7 @@
         "method": "GET",
         "humanName": "メールごとのユーザー",
         "requestUrl": "/v1.0/users/{user-mail}",
-        "docLink": "://developer.microsoft.com/ja-JP/graph/docs/api-reference/v1.0/resources/user",
+        "docLink": "https://developer.microsoft.com/ja-JP/graph/docs/api-reference/v1.0/resources/user",
         "tip": "ご意見をお聞かせください。ここにこの API に関するフィードバックを入力してください。https://aka.ms/UsersAPIFeedback",
         "skipTest": false
     },
@@ -197,7 +197,7 @@
         "method": "GET",
         "humanName": "ユーザー ID",
         "requestUrl": "/v1.0/users/{id | userPrincipalName}/identities",
-        "docLink": "://developer.microsoft.com/ja-JP/graph/docs/api-reference/v1.0/resources/user",
+        "docLink": "https://developer.microsoft.com/ja-JP/graph/docs/api-reference/v1.0/resources/user",
         "tip": "ご意見をお聞かせください。ここにこの API に関するフィードバックを入力してください。https://aka.ms/UsersAPIFeedback",
         "skipTest": false
     },


### PR DESCRIPTION
This is breaking production for the `ja-JP` locale option.