### PR TITLE
Updated requestURLs and docLinks for `GET items in a group/team drive`

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -428,8 +428,8 @@
         "category": "Groups",
         "method": "GET",
         "humanName": "items in a group drive",
-        "requestUrl": "/v1.0/groups/{group-id}/drive/root/children",
-        "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/drive_get",
+        "requestUrl": "/v1.0/groups/{group-id}/drive/items/root/children",
+        "docLink": "https://docs.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0&tabs=http",
         "tip": "This query requires a group id.  To find the ID of a group you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/memberOf",
         "skipTest": false
     },
@@ -1446,7 +1446,7 @@
         "category": "Microsoft Teams",
         "method": "GET",
         "humanName": "items in a team drive",
-        "requestUrl": "/v1.0/groups/{group-id-for-teams}/drive/root/children",
+        "requestUrl": "/v1.0/groups/{group-id-for-teams}/drive/items/root/children",
         "docLink": "https://docs.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0&tabs=http",
         "tip": "This query requires a group id of the Team.  To find the group id of Teams you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams",
         "skipTest": false


### PR DESCRIPTION
## Overview
* When we select the `GET items in a group drive` sample query in the `Groups (14)` dropdown, no permissions show up in the `Modify permissions (Preview)` tab:

![get_group_drive_children_before](https://user-images.githubusercontent.com/46834951/128580228-6fa48d1d-9de4-4bcf-a1ce-54ae562fe5a3.PNG)

* Similarly for the `GET items in a team drive` sample query in the `Microsoft Teams (11)` dropdown:

![get_team_drive_children_before](https://user-images.githubusercontent.com/46834951/128580265-059b6821-c550-493f-8ece-77430581f394.PNG)

* After cross-referencing with the [List children of a driveItem documentation](https://docs.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0&tabs=http), the issue seems to be that the request URLs in `devx-content` are missing `/items`
* Additionally, the documentation link for `GET items in a group drive` seems to point to the [Get Drive documentation](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/drive_get), instead of the [List children of a driveItem documentation](https://docs.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0&tabs=http) that matches the request URL.

### Demo

* Here is the `GET items in a group drive` sample query with `/items` added:

![get_group_drive_children_after](https://user-images.githubusercontent.com/46834951/128580370-bdf35043-f2c9-4bfe-b8cd-51a25700da98.PNG)

* Similarly for the `GET items in a team drive` sample query:

![get_team_drive_children_after](https://user-images.githubusercontent.com/46834951/128580387-6e1e6698-4903-454d-ae8a-cb43bb4b6425.PNG)

### Notes

## Testing Instructions
* Go to https://developer.microsoft.com/en-us/graph/graph-explorer?devx-api=https://graphexplorerapi.azurewebsites.net&org=LokiLabs&branchName=interns/jerryxihe/39604-update-list-drive-children-sample-query
* Select the `GET items in a group drive` sample query in the `Groups (14)` dropdown
* Verify that permissions show up in the `Modify permissions (Preview)`
* Verify that the documentation link takes you to the [List children of a driveItem documentation](https://docs.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0&tabs=http)
* Select the `GET items in a team drive` sample query in the `Microsoft Teams (11)` dropdown
* Verify that permissions show up in the `Modify permissions (Preview)`