### PR TITLE
Fixes Report.Read.All scope

### DIFF
--- a/permissions/permissions-beta.json
+++ b/permissions/permissions-beta.json
@@ -54991,20 +54991,20 @@
     "/reports/getazureadapplicationsigninsummary(period={value})": {
       "GET": {
         "Application": [
-          "Report.Read.All"
+          "Reports.Read.All"
         ],
         "DelegatedWork": [
-          "Report.Read.All"
+          "Reports.Read.All"
         ]
       }
     },
     "/reports/getrelyingpartydetailedsummary": {
       "GET": {
         "Application": [
-          "Report.Read.All"
+          "Reports.Read.All"
         ],
         "DelegatedWork": [
-          "Report.Read.All"
+          "Reports.Read.All"
         ]
       }
     },
@@ -77079,7 +77079,7 @@
     "/reports/applicationsignindetailedsummary/{id}": {
       "GET": {
         "DelegatedWork": [
-          "Report.Read.All"
+          "Reports.Read.All"
         ]
       }
     },


### PR DESCRIPTION
This PR:
- Corrects the invalid `Report.Read.All` to `Reports.Read.All`
Documentation: https://docs.microsoft.com/en-us/graph/api/applicationsigninsummary-get?view=graph-rest-beta&tabs=http