### PR TITLE
Remove duplicate `list all groups` query

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -299,15 +299,6 @@
       "skipTest": false
     },
     {
-      "id": "3d040b26-c26b-411a-9700-7fba8b327954",
-      "category": "Groups",
-      "method": "GET",
-      "humanName": "all groups in my organization",
-      "requestUrl": "/v1.0/groups",
-      "docLink": "https://docs.microsoft.com/en-us/graph/api/resources/group?view=graph-rest-1.0",
-      "skipTest": false
-    },
-    {
       "id": "6433ec9c-1ad5-4245-a5f2-8136c79856a9",
       "category": "Groups",
       "method": "GET",


### PR DESCRIPTION
This PR removes the duplicate queries labelled as `all groups in my organization` and `'list all groups in my organization` as they both have the same  request signature

Fixes : https://github.com/microsoftgraph/microsoft-graph-explorer-v4/issues/1565