### PR TITLE
Remove userPrincipalName from requestUrl

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -211,9 +211,9 @@
       "category": "Users",
       "method": "GET",
       "humanName": "user identities",
-      "requestUrl": "/v1.0/users/{id | userPrincipalName}/identities",
+      "requestUrl": "/v1.0/users/{id}/identities",
       "docLink": "https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0",
-      "tip": "We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback",
+      "tip": "We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback. You can also use 'userPrincipalName' in place of 'id'",
       "skipTest": false
     },
     {
@@ -247,7 +247,7 @@
       "category": "Users",
       "method": "PATCH",
       "humanName": "update user",
-      "requestUrl": "/v1.0/users/{id | userPrincipalName}",
+      "requestUrl": "/v1.0/users/{id}",
       "docLink": "https://docs.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0",
       "headers": [
         {
@@ -256,7 +256,7 @@
         }
       ],
       "postBody": "{\r\n        \"department\": \"Sales & Marketing\"\r\n    }",
-      "tip": "We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback",
+      "tip": "We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback. You can also use 'userPrincipalName' in place of 'id'",
       "skipTest": false
     },
     {
@@ -293,9 +293,9 @@
       "category": "Users",
       "method": "DELETE",
       "humanName": "delete user",
-      "requestUrl": "/v1.0/users/{id | userPrincipalName}",
+      "requestUrl": "/v1.0/users/{id}",
       "docLink": "https://docs.microsoft.com/en-us/graph/api/user-delete?view=graph-rest-1.0",
-      "tip": "We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback",
+      "tip": "We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback. You can also use 'userPrincipalName' in place of 'id'",
       "skipTest": false
     },
     {

--- a/tests/samples.spec.js
+++ b/tests/samples.spec.js
@@ -1,5 +1,5 @@
 const samples = require('../sample-queries/sample-queries.json');
-const { includesAllowedVersions, validateJson, validateLink } = require("./validator");
+const { includesAllowedVersions, validateJson, validateLink, hasWhiteSpace } = require("./validator");
 
 const sampleQueries = samples.SampleQueries;
 for (const query of sampleQueries) {
@@ -40,5 +40,9 @@ for (const query of sampleQueries) {
       const isValidLink = await validateLink(query.docLink);
       expect(isValidLink).toBe(true);
     });
+
+    it('requestUrl should not have whitespace before parameters', function () {
+      expect(hasWhiteSpace(query.requestUrl)).toBe(false);
+    })
   });
 }

--- a/tests/validator.js
+++ b/tests/validator.js
@@ -27,6 +27,14 @@ async function validateLink (linkUrl) {
   }
 }
 
+function hasWhiteSpace( sampleUrl ){
+  if(!sampleUrl) { return false }
+  const requestUrl = sampleUrl.split('?');
+  const whiteSpace = (requestUrl && requestUrl.length > 0) ? requestUrl[0].trim().indexOf(' ') : -1;
+  return whiteSpace === 1;
+}
+
 exports.validateJson = validateJson;
 exports.includesAllowedVersions = includesAllowedVersions;
 exports.validateLink = validateLink;
+exports.hasWhiteSpace = hasWhiteSpace;


### PR DESCRIPTION
Fixes #211 
Spaces within requestUrls are invalid. Notice that the edited request urls had spaces.
This can also be fixed by nipping the urls before they are displayed on Graph Explorer. However, this approach affects the readability of the urls. To demonstrate, nipping the space results in this requestUrl: **/v1.0/users/{id|userPrincipalName}/identities**. 