### PR TITLE
Remove trailing slashes from request urls

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -5,7 +5,7 @@
       "category": "Getting Started",
       "method": "GET",
       "humanName": "my profile",
-      "requestUrl": "/v1.0/me/",
+      "requestUrl": "/v1.0/me",
       "docLink": "https://docs.microsoft.com/en-us/graph/api/user-get",
       "skipTest": false
     },
@@ -772,7 +772,7 @@
       "category": "Excel",
       "method": "POST",
       "humanName": "add a new worksheet",
-      "requestUrl": "/v1.0/me/drive/items/{drive-item-id}/workbook/worksheets/",
+      "requestUrl": "/v1.0/me/drive/items/{drive-item-id}/workbook/worksheets",
       "docLink": "https://docs.microsoft.com/en-us/graph/api/worksheetcollection-add?view=graph-rest-1.0",
       "headers": [
         {


### PR DESCRIPTION
Trailing slashes on request URLs trigger autocomplete on Graph Explorer. Removing them ensures that autocomplete is triggered by user actions.