### PR TITLE
Task: Rename sample query "all the items in my drive" to "list items in my drive"

### DIFF
--- a/messages/GE.json
+++ b/messages/GE.json
@@ -68,7 +68,7 @@
   "modify permissions": "Modify permissions",
   "Save changes": "Save changes",
   "To change permissions, you will need to log-in again.": "To change permissions, you will need to log-in again.",
-  "all the items in my drive": "all the items in my drive",
+  "list items in my drive": "list items in my drive",
   "items trending around me": "items trending around me",
   "my direct reports": "my direct reports",
   "all users in the organization": "all users in the organization",

--- a/messages/GE.json
+++ b/messages/GE.json
@@ -68,7 +68,6 @@
   "modify permissions": "Modify permissions",
   "Save changes": "Save changes",
   "To change permissions, you will need to log-in again.": "To change permissions, you will need to log-in again.",
-  "all the items in my drive": "all the items in my drive",
   "list items in my drive": "list items in my drive",
   "items trending around me": "items trending around me",
   "my direct reports": "my direct reports",

--- a/messages/GE.json
+++ b/messages/GE.json
@@ -68,6 +68,7 @@
   "modify permissions": "Modify permissions",
   "Save changes": "Save changes",
   "To change permissions, you will need to log-in again.": "To change permissions, you will need to log-in again.",
+  "all the items in my drive": "all the items in my drive",
   "list items in my drive": "list items in my drive",
   "items trending around me": "items trending around me",
   "my direct reports": "my direct reports",

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -691,7 +691,7 @@
       "id": "308cee8e-cbc8-4d0a-995b-8d6e0fff7b44",
       "category": "OneDrive",
       "method": "GET",
-      "humanName": "all the items in my drive",
+      "humanName": "list items in my drive",
       "requestUrl": "/v1.0/me/drive/root/children",
       "docLink": "https://docs.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0",
       "skipTest": false

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -40,7 +40,7 @@
       "id": "7867209e-306d-41d2-bce7-30ca56bbab54",
       "category": "Getting Started",
       "method": "GET",
-      "humanName": "all the items in my drive",
+      "humanName": "list items in my drive",
       "requestUrl": "/v1.0/me/drive/root/children",
       "docLink": "https://docs.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0",
       "skipTest": false


### PR DESCRIPTION
### Overview
Fixes [Graph Example title is misleading #1550](https://github.com/microsoftgraph/microsoft-graph-explorer-v4/issues/1550)

### Notes
The issue was that the name of the sample query (v1.0/me/drive/root/children) named as **"all the items in my drive"** was misleading because of the nature of its response. The resolution is to rename the sample query to **"list items in my drive"** to have the name more aligned to the response, as also documented [here](https://learn.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0&tabs=http#response).

### Testing Instructions
