### PR TITLE
[Teams Targeting Service] Adding sample queries for teams targeting graph api's

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -3797,7 +3797,7 @@
       "category": "Teams Targeting",
       "method": "GET",
       "humanName": "get tags in a team",
-      "requestUrl": "/teams/{team-Id}/tags",
+      "requestUrl": "/beta/teams/{team-Id}/tags",
       "tip": "This query requires the TeamworkTag.Read permission",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktag-list?view=graph-rest-beta",
       "skipTest": false
@@ -3807,7 +3807,7 @@
       "category": "Teams Targeting",
       "method": "GET",
       "humanName": "get a single tag in a team",
-      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}",
+      "requestUrl": "/beta/teams/{team-Id}/tags/{teamworkTag-Id}",
       "tip": "This query requires the TeamworkTag.Read permission",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktag-get?view=graph-rest-beta",
       "skipTest": false
@@ -3817,7 +3817,7 @@
       "category": "Teams Targeting",
       "method": "POST",
       "humanName": "create a tag in a team",
-      "requestUrl": "/teams/{team-Id}/tags",
+      "requestUrl": "/beta/teams/{team-Id}/tags",
       "tip": "This query requires the TeamworkTag.ReadWrite permission",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktag-post?view=graph-rest-beta",
       "headers": [
@@ -3834,7 +3834,7 @@
       "category": "Teams Targeting",
       "method": "PATCH",
       "humanName": "update a tag in a team",
-      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}",
+      "requestUrl": "/beta/teams/{team-Id}/tags/{teamworkTag-Id}",
       "tip": "This query requires the TeamworkTag.ReadWrite permission",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktag-update?view=graph-rest-beta",
       "headers": [
@@ -3851,7 +3851,7 @@
       "category": "Teams Targeting",
       "method": "DELETE",
       "humanName": "delete a tag in a team",
-      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}",
+      "requestUrl": "/beta/teams/{team-Id}/tags/{teamworkTag-Id}",
       "tip": "This query requires the TeamworkTag.ReadWrite permission",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktag-delete?view=graph-rest-beta",
       "skipTest": false
@@ -3861,7 +3861,7 @@
       "category": "Teams Targeting",
       "method": "GET",
       "humanName": "gets all the members of a tag in a team",
-      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}/members",
+      "requestUrl": "/beta/teams/{team-Id}/tags/{teamworkTag-Id}/members",
       "tip": "This query requires the TeamworkTag.Read permission",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktagmember-list?view=graph-rest-beta",
       "skipTest": false
@@ -3871,7 +3871,7 @@
       "category": "Teams Targeting",
       "method": "GET",
       "humanName": "get a single member from a tag in a team",
-      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}/members/{teamworkTagMember-Id}",
+      "requestUrl": "/beta/teams/{team-Id}/tags/{teamworkTag-Id}/members/{teamworkTagMember-Id}",
       "tip": "This query requires the TeamworkTag.Read permission",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktagmember-get?view=graph-rest-beta",
       "skipTest": false
@@ -3881,7 +3881,7 @@
       "category": "Teams Targeting",
       "method": "POST",
       "humanName": "adds a member to a tag in a team",
-      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}/members",
+      "requestUrl": "/beta/teams/{team-Id}/tags/{teamworkTag-Id}/members",
       "tip": "This query requires the TeamworkTag.ReadWrite permission",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktag-post?view=graph-rest-beta",
       "headers": [
@@ -3898,7 +3898,7 @@
       "category": "Teams Targeting",
       "method": "DELETE",
       "humanName": "delete a member from a tag in a team",
-      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}/members/{teamworkTagMember-Id}",
+      "requestUrl": "/beta/teams/{team-Id}/tags/{teamworkTag-Id}/members/{teamworkTagMember-Id}",
       "tip": "This query requires the TeamworkTag.ReadWrite permission",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktagmember-delete?view=graph-rest-beta",
       "skipTest": false

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -3791,6 +3791,117 @@
       "tip": "This query requires the Sites.ReadWrite.All permission",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/sitepage-delete?view=graph-rest-beta",
       "skipTest": false
+    },
+    {
+      "id": "0047a04a-eba4-4112-a657-4993392f77a9",
+      "category": "Teams Targeting",
+      "method": "GET",
+      "humanName": "get tags in a team",
+      "requestUrl": "/teams/{team-Id}/tags",
+      "tip": "This query requires the TeamworkTag.Read permission",
+      "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktag-list?view=graph-rest-beta",
+      "skipTest": false
+    },
+    {
+      "id": "bbc63925-7a31-4d6b-8b8a-55e92ef2a770",
+      "category": "Teams Targeting",
+      "method": "GET",
+      "humanName": "get a single tag in a team",
+      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}",
+      "tip": "This query requires the TeamworkTag.Read permission",
+      "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktag-get?view=graph-rest-beta",
+      "skipTest": false
+    },
+    {
+      "id": "88b58998-ab6e-44b8-bfdc-b3536aa87edc",
+      "category": "Teams Targeting",
+      "method": "POST",
+      "humanName": "create a tag in a team",
+      "requestUrl": "/teams/{team-Id}/tags",
+      "tip": "This query requires the TeamworkTag.ReadWrite permission",
+      "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktag-post?view=graph-rest-beta",
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ],
+      "postBody":"{\n   \"displayName\": \"Finance\",\n   \"members\":[\n        {\n            \"userId\":\"92f6952f-61ca-4a94-8910-508a240bc167\"\n        },\n        {\n            \"userId\":\"085d800c-b86b-4bfc-a857-9371ad1caf29\"\n        }\n    ]\n}",
+      "skipTest": false
+    },
+    {
+      "id": "4e5f48d6-120c-4772-848d-f42f61c2c804",
+      "category": "Teams Targeting",
+      "method": "PATCH",
+      "humanName": "update a tag in a team",
+      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}",
+      "tip": "This query requires the TeamworkTag.ReadWrite permission",
+      "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktag-update?view=graph-rest-beta",
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ],
+      "postBody":"{\n   \"displayName\": \"Finance\"\n}",
+      "skipTest": false
+    },
+    {
+      "id": "28cbb474-b2bb-49af-a6e6-83207561fb03",
+      "category": "Teams Targeting",
+      "method": "DELETE",
+      "humanName": "delete a tag in a team",
+      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}",
+      "tip": "This query requires the TeamworkTag.ReadWrite permission",
+      "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktag-delete?view=graph-rest-beta",
+      "skipTest": false
+    },
+    {
+      "id": "aa27a0c0-b764-47dc-adac-b927f9c1382a",
+      "category": "Teams Targeting",
+      "method": "GET",
+      "humanName": "gets all the members of a tag in a team",
+      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}/members",
+      "tip": "This query requires the TeamworkTag.Read permission",
+      "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktagmember-list?view=graph-rest-beta",
+      "skipTest": false
+    },
+    {
+      "id": "bae6519b-cd9b-4380-a9f8-4bd2da5d5521",
+      "category": "Teams Targeting",
+      "method": "GET",
+      "humanName": "get a single member from a tag in a team",
+      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}/members/{teamworkTagMember-Id}",
+      "tip": "This query requires the TeamworkTag.Read permission",
+      "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktagmember-get?view=graph-rest-beta",
+      "skipTest": false
+    },
+    {
+      "id": "f483adbe-3910-49da-b68a-bce48cf222e6",
+      "category": "Teams Targeting",
+      "method": "POST",
+      "humanName": "adds a member to a tag in a team",
+      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}/members",
+      "tip": "This query requires the TeamworkTag.ReadWrite permission",
+      "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktag-post?view=graph-rest-beta",
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ],
+      "postBody":"{\n   \"userId\": \"92f6952f-61ca-4a94-8910-508a240bc167\"\n}",
+      "skipTest": false
+    },
+    {
+      "id": "edb4ea43-0d51-4652-b42a-f3c3f09c1f8b",
+      "category": "Teams Targeting",
+      "method": "DELETE",
+      "humanName": "delete a member from a tag in a team",
+      "requestUrl": "/teams/{team-Id}/tags/{teamworkTag-Id}/members/{teamworkTagMember-Id}",
+      "tip": "This query requires the TeamworkTag.ReadWrite permission",
+      "docLink": "https://learn.microsoft.com/en-us/graph/api/teamworktagmember-delete?view=graph-rest-beta",
+      "skipTest": false
     }
   ]
 }


### PR DESCRIPTION
Adding sample queries for Teams Targeting Service's graph apis:
GET /teams/{team-Id}/tags
POST /teams/{team-Id}/tags
GET /teams/{team-Id}/tags/{teamworkTag-Id}
PATCH /teams/{team-Id}/tags/{teamworkTag-Id}
DELETE /teams/{team-Id}/tags/{teamworkTag-Id}
GET /teams/{team-Id}/tags/{teamworkTag-Id}/members
POST /teams/{team-Id}/tags/{teamworkTag-Id}/members
GET /teams/{team-Id}/tags/{teamworkTag-Id}/members/{teamworkTagMember-Id}
DELETE /teams/{team-Id}/tags/{teamworkTag-Id}/members/{teamworkTagMember-Id}