### PR TITLE
Fixed typo and structure of sample queries

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -4027,10 +4027,13 @@
       "humanName": "get list item delta",
       "requestUrl": "/beta/sites/root/lists/{list-id}/items/delta",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/listitem-delta?view=graph-rest-beta&tabs=http",
+      "skipTest": false
+    },
+    {
       "id": "62e117e6-ac63-465a-9868-d1b901f2e530",
       "category": "Viva Goals",
       "method": "GET",
-      "humanName": "get the properties of goalsExportJobs in a Viva goals organization",
+      "humanName": "get the properties of a goalsExportJob in a Viva goals organization",
       "requestUrl": "/beta/employeeExperience/goals/exportJobs/{jobId}",
       "tip": "This query requires the Goals-Export.Read.All/Goals-Export.ReadWrite.All permission",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/goalsexportjob-get?view=graph-rest-beta",
@@ -4040,7 +4043,7 @@
       "id": "f80fc68a-b297-4869-848a-1fbd088cd6be",
       "category": "Viva Goals",
       "method": "GET",
-      "humanName": "get a list of for goalsExportJobs in a Viva goals organization",
+      "humanName": "get a list of goalsExportJobs in a Viva goals organization",
       "requestUrl": "/beta/employeeExperience/goals/exportJobs",
       "tip": "This query requires the Goals-Export.Read.All/Goals-Export.ReadWrite.All permission",
       "docLink": "https://learn.microsoft.com/en-us/graph/api/goals-list-exportjobs?view=graph-rest-beta",


### PR DESCRIPTION
1. Fixed Typo
2. I just saw that somebody pushed some changes related to "Scan Guidance APIs"
They added it above "Viva Goals" and Object was messed up. Not sure how build got validated. 
@andrueastman : Could you please check this once? 
https://github.com/microsoftgraph/microsoft-graph-devx-content/pull/404/files