### PR TITLE
Added path filter to validate.yml

### DIFF
--- a/.github/workflows/validate-patch.yml
+++ b/.github/workflows/validate-patch.yml
@@ -1,0 +1,29 @@
+# This file mirrors validate.yml and is designed to be a
+# "stand-in" that always passes so that pull requests are not
+# blocked waiting on the "Validate sample queries" workflow.
+# For context, validate.yml will only run if specific files are
+# updated in the PR. If a PR doesn't touch any of those files,
+# validate.yml will never run, but since it's a required status
+# check for PRs, the PR will be stuck waiting for the workflow to run.
+# This file solves that problem. For more info, see
+# https://github.com/orgs/community/discussions/44490
+name: Validate sample queries
+on:
+  pull_request:
+    paths-ignore:
+      - /sample-queries/sample-queries.json
+      - /scripts/**
+      - /tests/**
+      - /package.json
+      - /package-lock.json
+
+jobs:
+  validate-json-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No validation required"'
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No tests required"'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,19 @@
 name: Validate sample queries
-on: [pull_request,push]
+on:
+  push:
+    paths:
+      - /sample-queries/sample-queries.json
+      - /scripts/**
+      - /tests/**
+      - /package.json
+      - /package-lock.json
+  pull_request:
+    paths:
+      - /sample-queries/sample-queries.json
+      - /scripts/**
+      - /tests/**
+      - /package.json
+      - /package-lock.json
 
 jobs:
   validate-json-schema:
@@ -18,8 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install 
-        run: npm install   
+      - name: Install
+        run: npm install
 
       - name: Run test
         run: npm run test


### PR DESCRIPTION
So now the validation will only run if relevant files are changed. There's no reason to run validation on sample queries if only permissions files are changed, for example.

Also added an opposite-filtered version of the workflow in validate-patch.yml. This will allow us to make this a required status check on PRs without blocking PRs that don't touch relevant files. See https://github.com/orgs/community/discussions/44490 for context.